### PR TITLE
fix(meteor): background-relative hot mask, remove dev-mode gate, add pipeline diagnostics

### DIFF
--- a/docs/METEOR_DETECTION_PLAN.md
+++ b/docs/METEOR_DETECTION_PLAN.md
@@ -30,6 +30,26 @@
 > Phase 6 (cleanup/graduation), corpus collection. Watch file sizes:
 > `meteor_controller.py` 594 / `image_processor.py` 597 vs the 600 target.
 
+> **Update (2026-07-07): field fix after two silent weeks.** Zero detections
+> in production traced to `hot_mask()` using an ABSOLUTE `pixel > 5` test:
+> the linear detection frame's floor sits at the sensor offset + sky
+> background (10–30 DN, auto-exposure mean ~100), so every pixel counted as
+> "hot" and the transient map was zeroed before Hough ever ran. `hot_mask()`
+> is now background-relative (pixel > per-frame median + threshold, still
+> ANDed over the stack) — regression tests in `test_meteor_stack.py` use a
+> realistic ~25 DN background, which the original synthetic tests (0 DN) did
+> not. Two decisions changed with Paul's sign-off:
+> - **The dev-mode gate is removed** (`meteor_controller.py`,
+>   `image_processor.py`) — the feature ships under the Beta badge like
+>   ML Models; `meteor.enabled` is the only gate. The Phase 6 exit criteria
+>   now govern removing the Beta badge instead.
+> - New `services/meteor/diagnostics.py` (`MeteorDiagnostics`) makes silent
+>   nights diagnosable from the log: periodic INFO heartbeat with per-stage
+>   candidate counts (raw → length → profile → released/planes), a one-shot
+>   "frames stopped — none since HH:MM:SS" line, roof-gate suspend/resume
+>   transitions, and a WARNING when hot-mask coverage exceeds 40% of the
+>   frame. Sky-circle resolution failure is now a WARNING (was debug).
+
 ---
 
 ## The Problem

--- a/services/meteor/diagnostics.py
+++ b/services/meteor/diagnostics.py
@@ -1,0 +1,213 @@
+"""
+Meteor pipeline diagnostics.
+
+Answers the two questions a silent night raises:
+  1. "Did frames stop reaching the detector — and when?" A one-shot
+     'frames stopped' line records the last-frame timestamp when the flow
+     dries up, and a 'frames resumed' line marks recovery.
+  2. "Frames flowed but nothing fired — where did candidates die?" A periodic
+     INFO heartbeat summarises per-stage counters (raw Hough candidates →
+     length ceiling → streak profile → persistence verdicts) plus the current
+     noise threshold and hot-mask coverage, so a zero-detection night is
+     attributable to a specific stage from the log alone.
+
+Also logs transitions: roof-gate suspend/resume, and a WARNING when the hot
+mask blankets an implausible fraction of the frame (the transient map is then
+mostly blanked and detection cannot fire).
+
+All log lines go through app_logger. Methods return the message they logged
+(None when nothing was logged) so tests can assert without capturing logs.
+
+Thread-safety: frame_received()/roof_gate()/detection_*() are called from the
+frame-ingest slot and the detection worker thread; maybe_heartbeat() from the
+GUI status timer. All mutable state sits behind one lock.
+"""
+import threading
+import time
+from datetime import datetime
+from typing import Callable, Optional
+
+from services.logger import app_logger
+
+# Above this fraction of masked pixels the hot mask is almost certainly
+# eating sky background rather than equipment — warn loudly.
+HOT_MASK_WARN_FRACTION = 0.4
+
+
+class MeteorDiagnostics:
+    """Aggregates pipeline counters and emits periodic/transition log lines."""
+
+    def __init__(self, heartbeat_minutes: float = 15.0,
+                 now_fn: Callable[[], float] = time.monotonic):
+        self._interval = heartbeat_minutes * 60.0
+        self._now = now_fn
+        self._lock = threading.Lock()
+        self._reset_counters()
+        self._last_frame_mono: Optional[float] = None
+        self._last_frame_wall: str = ""
+        self._last_heartbeat_mono: Optional[float] = None
+        self._silence_logged = False
+        self._roof_suspended = False
+        self._hot_warned = False
+        self._sigma: float = 0.0
+        self._threshold: int = 0
+        self._hot_coverage: float = 0.0
+
+    def _reset_counters(self):
+        self._frames = 0
+        self._runs = 0
+        self._skipped = {"warming": 0, "cooldown": 0, "busy": 0}
+        self._raw = 0
+        self._after_length = 0
+        self._after_profile = 0
+        self._released = 0
+        self._planes = 0
+
+    # ------------------------------------------------------------------ #
+    #  Ingest events                                                       #
+    # ------------------------------------------------------------------ #
+
+    def frame_received(self) -> Optional[str]:
+        with self._lock:
+            self._frames += 1
+            self._last_frame_mono = self._now()
+            self._last_frame_wall = datetime.now().strftime("%H:%M:%S")
+            if self._last_heartbeat_mono is None:
+                self._last_heartbeat_mono = self._last_frame_mono
+            if not self._silence_logged:
+                return None
+            self._silence_logged = False
+        msg = "Meteor: frames resumed — detection active again"
+        app_logger.info(msg)
+        return msg
+
+    def roof_gate(self, closed: bool) -> Optional[str]:
+        """Call every frame with the roof state; logs only on transitions."""
+        with self._lock:
+            if closed == self._roof_suspended:
+                return None
+            self._roof_suspended = closed
+        msg = ("Meteor: detection suspended — roof reported closed" if closed
+               else "Meteor: detection resumed — roof reported open")
+        app_logger.info(msg)
+        return msg
+
+    def detection_skipped(self, reason: str) -> None:
+        """reason: 'warming' | 'cooldown' | 'busy'."""
+        with self._lock:
+            if reason in self._skipped:
+                self._skipped[reason] += 1
+
+    def detection_run(self, hot_coverage: float, sigma: float, threshold: int,
+                      raw: int, after_length: int, after_profile: int,
+                      released: int, planes: int) -> Optional[str]:
+        """Record one detection run's stage counts. Returns the hot-mask
+        warning message when coverage crosses the warn fraction, else None."""
+        with self._lock:
+            self._runs += 1
+            self._raw += raw
+            self._after_length += after_length
+            self._after_profile += after_profile
+            self._released += released
+            self._planes += planes
+            self._sigma = sigma
+            self._threshold = threshold
+            self._hot_coverage = hot_coverage
+            warn = hot_coverage >= HOT_MASK_WARN_FRACTION and not self._hot_warned
+            recovered = hot_coverage < HOT_MASK_WARN_FRACTION and self._hot_warned
+            self._hot_warned = hot_coverage >= HOT_MASK_WARN_FRACTION
+
+        if warn:
+            msg = (f"Meteor: hot mask covers {hot_coverage * 100:.0f}% of the "
+                   "frame — transient map is mostly blanked and detection "
+                   "cannot fire (detection-frame background too bright?)")
+            app_logger.warning(msg)
+            return msg
+        if recovered:
+            msg = (f"Meteor: hot mask coverage back to "
+                   f"{hot_coverage * 100:.1f}% — detection unblocked")
+            app_logger.info(msg)
+            return msg
+        return None
+
+    # ------------------------------------------------------------------ #
+    #  Periodic heartbeat                                                  #
+    # ------------------------------------------------------------------ #
+
+    def maybe_heartbeat(self, enabled: bool) -> Optional[str]:
+        """Call periodically (e.g. from a QTimer). Emits at most one line:
+        either the interval heartbeat or the one-shot 'frames stopped' note."""
+        if not enabled:
+            return None
+        now = self._now()
+        with self._lock:
+            if self._last_frame_mono is None:
+                return None  # never saw a frame — capture not started
+
+            # Frames dried up: say so ONCE, with the last-frame timestamp.
+            # Heartbeats pause until frames resume — the pre-silence counters
+            # are stale and a periodic summary of a dead pipeline is noise.
+            if (not self._silence_logged
+                    and now - self._last_frame_mono >= self._interval):
+                self._silence_logged = True
+                minutes = (now - self._last_frame_mono) / 60.0
+                last_wall = self._last_frame_wall
+                self._reset_counters()
+                self._last_heartbeat_mono = now
+                msg = (f"Meteor: frames stopped — none since {last_wall} "
+                       f"({minutes:.0f} min ago); capture stalled, meteor "
+                       "disabled mid-session, or app idle")
+                app_logger.info(msg)
+                return msg
+
+            if (self._silence_logged
+                    or self._last_heartbeat_mono is None
+                    or now - self._last_heartbeat_mono < self._interval
+                    or self._frames == 0):
+                return None
+            msg = self._format_heartbeat()
+            self._last_heartbeat_mono = now
+            self._reset_counters()
+        app_logger.info(msg)
+        return msg
+
+    def flush(self, reason: str) -> Optional[str]:
+        """Emit a final heartbeat immediately (e.g. on capture stop)."""
+        with self._lock:
+            if self._frames == 0 and self._runs == 0:
+                return None
+            msg = f"{self._format_heartbeat()} [{reason}]"
+            self._reset_counters()
+        app_logger.info(msg)
+        return msg
+
+    def reset(self) -> None:
+        """Discard all state (capture stop / session change)."""
+        with self._lock:
+            self._reset_counters()
+            self._last_frame_mono = None
+            self._last_frame_wall = ""
+            self._last_heartbeat_mono = None
+            self._silence_logged = False
+            self._roof_suspended = False
+            self._hot_warned = False
+
+    # ------------------------------------------------------------------ #
+    #  Formatting (call with lock held)                                    #
+    # ------------------------------------------------------------------ #
+
+    def _format_heartbeat(self) -> str:
+        skipped = ", ".join(f"{v} {k}" for k, v in self._skipped.items() if v)
+        parts = [
+            f"Meteor heartbeat: {self._frames} frames, {self._runs} detection "
+            f"run(s)" + (f" ({skipped} skipped)" if skipped else ""),
+            f"candidates {self._raw} raw -> {self._after_length} length-ok -> "
+            f"{self._after_profile} profile-ok",
+            f"{self._released} meteor(s) released, "
+            f"{self._planes} plane track(s) suppressed",
+            f"hot mask {self._hot_coverage * 100:.1f}%, "
+            f"threshold {self._threshold} (sigma={self._sigma:.2f})",
+        ]
+        if self._roof_suspended:
+            parts.append("roof gate ACTIVE")
+        return "; ".join(parts)

--- a/services/meteor/frame_stack.py
+++ b/services/meteor/frame_stack.py
@@ -107,13 +107,19 @@ class FrameStack:
 
     def hot_mask(self, threshold: int = 5) -> np.ndarray:
         """
-        Binary mask (255 = hot pixel) for pixels that exceed *threshold*
-        in EVERY frame of the current stack.
+        Binary mask (255 = hot pixel) for pixels that exceed their frame's
+        own background (per-frame median) by *threshold* in EVERY frame of
+        the current stack.
 
         These are static artefacts (equipment edges, hot pixels) that should
-        be suppressed before Hough detection. No erosion is applied — thin
-        equipment lines (the primary target) are 1–2 px wide and erosion
-        would remove them from the mask entirely.
+        be suppressed before Hough detection. The test is background-RELATIVE:
+        the linear detection frame's floor sits at the sensor offset plus sky
+        background (typically 10–30 DN, and auto-exposure pushes the mean far
+        above that), so an absolute `pixel > threshold` test marks the entire
+        frame hot and blanks the transient map — no detection can ever fire.
+
+        No erosion is applied — thin equipment lines (the primary target)
+        are 1–2 px wide and erosion would remove them from the mask entirely.
 
         Returns a zero mask if the stack has fewer than 2 frames.
         """
@@ -121,4 +127,8 @@ class FrameStack:
             shape = self._frames[0].shape if self._frames else (1, 1)
             return np.zeros(shape, np.uint8)
         stacked = np.array(self._frames, dtype=np.uint8)
-        return (np.all(stacked > threshold, axis=0).astype(np.uint8) * 255)
+        backgrounds = np.median(
+            stacked.reshape(stacked.shape[0], -1), axis=1).astype(np.float32)
+        limits = backgrounds[:, None, None] + float(threshold)
+        hot = np.all(stacked.astype(np.float32) > limits, axis=0)
+        return hot.astype(np.uint8) * 255

--- a/tests/test_meteor_diagnostics.py
+++ b/tests/test_meteor_diagnostics.py
@@ -1,0 +1,170 @@
+"""Tests for services/meteor/diagnostics.py — heartbeat, silence detection,
+roof-gate transitions, and the hot-mask coverage warning."""
+import os
+import sys
+
+import pytest
+
+project_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if project_root not in sys.path:
+    sys.path.insert(0, project_root)
+
+from services.meteor.diagnostics import MeteorDiagnostics, HOT_MASK_WARN_FRACTION
+
+
+class FakeClock:
+    def __init__(self):
+        self.t = 1000.0
+
+    def __call__(self) -> float:
+        return self.t
+
+    def advance(self, seconds: float):
+        self.t += seconds
+
+
+@pytest.fixture()
+def clock():
+    return FakeClock()
+
+
+@pytest.fixture()
+def diag(clock):
+    return MeteorDiagnostics(heartbeat_minutes=15.0, now_fn=clock)
+
+
+def _run(diag, **overrides):
+    kwargs = dict(hot_coverage=0.02, sigma=1.4, threshold=6,
+                  raw=0, after_length=0, after_profile=0,
+                  released=0, planes=0)
+    kwargs.update(overrides)
+    return diag.detection_run(**kwargs)
+
+
+class TestHeartbeat:
+    def test_no_heartbeat_before_any_frame(self, diag):
+        assert diag.maybe_heartbeat(enabled=True) is None
+
+    def test_no_heartbeat_when_disabled(self, diag, clock):
+        diag.frame_received()
+        clock.advance(3600)
+        assert diag.maybe_heartbeat(enabled=False) is None
+
+    def test_no_heartbeat_before_interval(self, diag, clock):
+        diag.frame_received()
+        _run(diag)
+        clock.advance(60)
+        assert diag.maybe_heartbeat(enabled=True) is None
+
+    def test_heartbeat_after_interval_summarises_stages(self, diag, clock):
+        diag.frame_received()
+        _run(diag, raw=4, after_length=3, after_profile=2, released=1, planes=1)
+        clock.advance(15 * 60)
+        diag.frame_received()   # keep the frame flow alive across the interval
+        msg = diag.maybe_heartbeat(enabled=True)
+        assert msg is not None
+        assert "2 frames" in msg
+        assert "4 raw -> 3 length-ok -> 2 profile-ok" in msg
+        assert "1 meteor(s) released" in msg
+        assert "1 plane track(s) suppressed" in msg
+
+    def test_counters_reset_after_heartbeat(self, diag, clock):
+        diag.frame_received()
+        _run(diag, raw=4)
+        clock.advance(15 * 60)
+        diag.frame_received()
+        diag.maybe_heartbeat(enabled=True)
+        clock.advance(15 * 60)
+        diag.frame_received()
+        msg = diag.maybe_heartbeat(enabled=True)
+        assert "0 raw" in msg, "Stage counters must reset between heartbeats"
+
+    def test_skip_reasons_included(self, diag, clock):
+        diag.frame_received()
+        diag.detection_skipped("cooldown")
+        diag.detection_skipped("cooldown")
+        diag.detection_skipped("busy")
+        clock.advance(15 * 60)
+        diag.frame_received()
+        msg = diag.maybe_heartbeat(enabled=True)
+        assert "2 cooldown" in msg
+        assert "1 busy" in msg
+
+
+class TestSilenceDetection:
+    def test_frames_stopped_logged_once_with_last_time(self, diag, clock):
+        diag.frame_received()
+        clock.advance(20 * 60)
+        msg = diag.maybe_heartbeat(enabled=True)
+        assert msg is not None and "frames stopped" in msg
+        assert "20 min ago" in msg
+        # Only once per silence period
+        clock.advance(20 * 60)
+        assert diag.maybe_heartbeat(enabled=True) is None
+
+    def test_frames_resumed_after_silence(self, diag, clock):
+        diag.frame_received()
+        clock.advance(20 * 60)
+        diag.maybe_heartbeat(enabled=True)
+        msg = diag.frame_received()
+        assert msg is not None and "frames resumed" in msg
+
+    def test_no_resume_message_without_prior_silence(self, diag):
+        assert diag.frame_received() is None
+        assert diag.frame_received() is None
+
+
+class TestRoofGate:
+    def test_transitions_logged_once(self, diag):
+        assert diag.roof_gate(False) is None          # open is the start state
+        msg = diag.roof_gate(True)
+        assert msg is not None and "suspended" in msg
+        assert diag.roof_gate(True) is None           # no repeat while closed
+        msg = diag.roof_gate(False)
+        assert msg is not None and "resumed" in msg
+
+    def test_roof_state_shown_in_heartbeat(self, diag, clock):
+        diag.frame_received()
+        diag.roof_gate(True)
+        clock.advance(15 * 60)
+        diag.frame_received()
+        msg = diag.maybe_heartbeat(enabled=True)
+        assert "roof gate ACTIVE" in msg
+
+
+class TestHotMaskWarning:
+    def test_warns_when_coverage_crosses_threshold(self, diag):
+        msg = _run(diag, hot_coverage=HOT_MASK_WARN_FRACTION + 0.4)
+        assert msg is not None and "hot mask covers 80%" in msg
+
+    def test_warns_only_on_transition(self, diag):
+        _run(diag, hot_coverage=0.9)
+        assert _run(diag, hot_coverage=0.9) is None
+
+    def test_recovery_logged(self, diag):
+        _run(diag, hot_coverage=0.9)
+        msg = _run(diag, hot_coverage=0.05)
+        assert msg is not None and "unblocked" in msg
+
+    def test_no_warning_at_normal_coverage(self, diag):
+        assert _run(diag, hot_coverage=0.05) is None
+
+
+class TestFlushAndReset:
+    def test_flush_emits_final_summary(self, diag):
+        diag.frame_received()
+        _run(diag, raw=1)
+        msg = diag.flush("capture stopped")
+        assert msg is not None and "[capture stopped]" in msg
+
+    def test_flush_silent_when_nothing_counted(self, diag):
+        assert diag.flush("capture stopped") is None
+
+    def test_reset_clears_silence_and_roof_state(self, diag, clock):
+        diag.frame_received()
+        diag.roof_gate(True)
+        clock.advance(20 * 60)
+        diag.maybe_heartbeat(enabled=True)
+        diag.reset()
+        assert diag.maybe_heartbeat(enabled=True) is None  # no frame yet
+        assert diag.roof_gate(True) is not None            # transitions re-arm

--- a/tests/test_meteor_stack.py
+++ b/tests/test_meteor_stack.py
@@ -78,6 +78,46 @@ class TestFrameStack:
         # Single-frame streak should NOT be masked
         assert hot[32, 30] == 0, "Single-frame streak must not appear in hot mask"
 
+    def test_hot_mask_ignores_uniform_background(self):
+        """Regression: linear detection frames sit at the sensor offset plus
+        sky background (~10-30 DN). An absolute threshold marked the ENTIRE
+        frame hot, blanking the transient map — zero detections in the field.
+        The mask must be background-relative."""
+        fs = FrameStack(maxlen=4)
+        for _ in range(4):
+            fs.push(_gray(fill=25))
+        hot = fs.hot_mask(threshold=5)
+        assert hot.max() == 0, (
+            "Uniform background above the absolute threshold must not be "
+            f"masked: {100 * (hot > 0).mean():.0f}% of frame marked hot")
+
+    def test_hot_mask_marks_equipment_edge_above_background(self):
+        fs = FrameStack(maxlen=4)
+        for _ in range(4):
+            frame = _gray(fill=25)
+            frame[40, :] = 120   # bright static equipment line in every frame
+            fs.push(frame)
+        hot = fs.hot_mask(threshold=5)
+        assert hot[40, 32] == 255, "Static bright edge should be masked"
+        assert hot[10, 32] == 0, "Plain background should not be masked"
+
+    def test_streak_survives_hot_mask_on_realistic_background(self):
+        """End-to-end field regression: one-frame streak over a ~25 DN
+        background must survive the hot-mask suppression step exactly as the
+        controller applies it (transient zeroed where hot)."""
+        fs = FrameStack(maxlen=4)
+        for _ in range(3):
+            fs.push(_gray(fill=25))
+        streak = _gray(fill=25)
+        streak[32, 10:54] = 120
+        fs.push(streak)
+        transient = fs.transient_map()
+        hot = fs.hot_mask(threshold=5)
+        masked = transient.copy()
+        masked[hot > 0] = 0
+        assert masked[32, 30] > 50, (
+            f"Streak must survive hot-mask suppression: value={masked[32, 30]}")
+
     def test_push_evicts_oldest_frame(self):
         fs = FrameStack(maxlen=3)
         for i in range(4):

--- a/ui/controllers/image_processor.py
+++ b/ui/controllers/image_processor.py
@@ -228,18 +228,16 @@ class ImageProcessorWorker(QThread):
             _det_frame = None
             _meteor_cfg = config.get('meteor', {})
             if _meteor_cfg.get('enabled', False):
-                from services.dev_mode_config import is_dev_mode_available
-                if is_dev_mode_available():
-                    _det_long_side = int(_meteor_cfg.get('detection_long_side', 1280))
-                    _det_factor = min(1.0, _det_long_side / max(img.width, img.height))
-                    if _det_factor < 1.0:
-                        _det_frame = img.resize(
-                            (max(1, int(img.width * _det_factor)),
-                             max(1, int(img.height * _det_factor))),
-                            Image.Resampling.LANCZOS,
-                        ).convert('L')
-                    else:
-                        _det_frame = img.convert('L')
+                _det_long_side = int(_meteor_cfg.get('detection_long_side', 1280))
+                _det_factor = min(1.0, _det_long_side / max(img.width, img.height))
+                if _det_factor < 1.0:
+                    _det_frame = img.resize(
+                        (max(1, int(img.width * _det_factor)),
+                         max(1, int(img.height * _det_factor))),
+                        Image.Resampling.LANCZOS,
+                    ).convert('L')
+                else:
+                    _det_frame = img.convert('L')
 
             # Apply auto-stretch (MTF) if enabled
             # Use 16-bit raw data when available for higher precision stretching

--- a/ui/controllers/meteor_controller.py
+++ b/ui/controllers/meteor_controller.py
@@ -26,8 +26,8 @@ from PIL import Image
 from PySide6.QtCore import QObject, Signal, QTimer
 
 from services.logger import app_logger
-from services.dev_mode_config import is_dev_mode_available
 from services.meteor.detection_scale import DetectionScale, make_scale
+from services.meteor.diagnostics import MeteorDiagnostics
 from services.meteor.frame_stack import FrameStack
 from services.meteor.noise import DiffNoiseEMA, noise_to_threshold
 from services.meteor.detector import detect_meteors, MeteorDetection, annotate_image
@@ -81,9 +81,12 @@ class MeteorController(QObject):
         # from the current one by definition. Detection-thread access only.
         self._held_full_res: Optional[Image.Image] = None
 
+        self._diag = MeteorDiagnostics()
+
         self._status_timer = QTimer(self)
         self._status_timer.setInterval(5000)
         self._status_timer.timeout.connect(self._emit_status)
+        self._status_timer.timeout.connect(self._on_diag_tick)
         self._status_timer.start()
 
     # ------------------------------------------------------------------ #
@@ -97,16 +100,17 @@ class MeteorController(QObject):
         *detection_gray*: grayscale PIL Image at detection scale, pre-stretch.
         *full_res_clean*: full-resolution stretched clean PIL Image for thumbnails.
         """
-        if not is_dev_mode_available():
-            return
         cfg = self._get_config()
         if not cfg.get("enabled", False):
             return
+        self._diag.frame_received()
 
         # Roof gate — invalidate the whole pipeline when confirmed closed, so a
         # stale pre-closure candidate can't be released after reopening.
         ml_results = getattr(self._main_window, 'last_ml_results', None) or {}
-        if ml_results.get('roof_status') == 'Closed':
+        roof_closed = ml_results.get('roof_status') == 'Closed'
+        self._diag.roof_gate(roof_closed)
+        if roof_closed:
             if self._stack and self._detection_semaphore.acquire(blocking=False):
                 try:
                     self._stack.clear()
@@ -161,6 +165,7 @@ class MeteorController(QObject):
         self._frame_idx += 1
 
         if not self._stack.full:
+            self._diag.detection_skipped("warming")
             app_logger.debug(
                 f"Meteor: stack warming ({self._stack.count}/{self._stack.maxlen})")
             return
@@ -169,10 +174,12 @@ class MeteorController(QObject):
         # reported streak evicts naturally) but skip detection runs.
         cooldown = float(cfg.get("detection_cooldown", 30))
         if cooldown > 0 and (time.monotonic() - self._last_detection_ts) < cooldown:
+            self._diag.detection_skipped("cooldown")
             return
 
         # Non-blocking: drop frame if a detection thread is already running
         if not self._detection_semaphore.acquire(blocking=False):
+            self._diag.detection_skipped("busy")
             return
 
         transient = self._stack.transient_map()
@@ -236,11 +243,13 @@ class MeteorController(QObject):
                 max_nonline_prob=float(cfg.get("max_nonline_prob", 0.15)),
                 min_brightness=int(cfg.get("min_brightness", 20)),
             )
+            raw_count = len(detections)
 
             # Absolute length ceiling: a streak spanning most of the sky in one
             # exposure is a satellite/plane/ISS pass, not a verifiable meteor.
             max_len_det = float(cfg.get("max_length_frac", 0.5)) * transient.shape[1]
             detections = [d for d in detections if d.length <= max_len_det]
+            after_length_count = len(detections)
 
             # Scale detections back to full-res coords for thumbnails and zones
             if detections and scale and scale.factor < 1.0:
@@ -255,21 +264,35 @@ class MeteorController(QObject):
 
             if detections:
                 detections = self._apply_profile_filters(detections, full_res, cfg)
+            after_profile_count = len(detections)
 
             # Persistence filter: hold one frame, report as meteor if absent
             # next frame. Must run EVERY frame — an empty frame is what releases
             # the previous frame's held candidate as a meteor.
+            released_count = 0
+            plane_count = 0
             if self._filter:
                 prev_held_img = self._held_full_res
                 released, planes = self._filter.update(detections, frame_idx)
                 self._held_full_res = full_res if detections else None
+                plane_count = planes
                 if planes:
                     app_logger.debug(f"Meteor: {planes} plane track(s) suppressed")
                 if released:
+                    released_count = len(released)
                     self._report_detections(
                         released, prev_held_img or full_res, cfg)
             elif detections:
+                released_count = len(detections)
                 self._report_detections(detections, full_res, cfg)
+
+            hot_coverage = (float((hot_mask > 0).mean())
+                            if hot_mask is not None and hot_mask.size else 0.0)
+            self._diag.detection_run(
+                hot_coverage=hot_coverage, sigma=sigma, threshold=threshold,
+                raw=raw_count, after_length=after_length_count,
+                after_profile=after_profile_count,
+                released=released_count, planes=plane_count)
 
         except Exception as exc:
             app_logger.error(f"Meteor detection error: {exc}")
@@ -459,6 +482,8 @@ class MeteorController(QObject):
     # ------------------------------------------------------------------ #
 
     def on_capture_stopped(self):
+        self._diag.flush("capture stopped")
+        self._diag.reset()
         # Wait for an in-flight detection thread before tearing down — it
         # reads _filter/_noise_ema/_held_full_res and reports into
         # _recent_events; tearing down underneath it races.
@@ -526,6 +551,16 @@ class MeteorController(QObject):
     def _emit_status(self):
         self.status_updated.emit(self.get_status())
 
+    def _on_diag_tick(self):
+        """Periodic diagnostics heartbeat — GUI status-timer thread."""
+        if self._main_window is None:
+            return
+        try:
+            enabled = bool(self._get_config().get("enabled", False))
+        except AttributeError:
+            return
+        self._diag.maybe_heartbeat(enabled)
+
     # ------------------------------------------------------------------ #
     #  Helpers                                                             #
     # ------------------------------------------------------------------ #
@@ -556,8 +591,10 @@ class MeteorController(QObject):
                 f"Meteor: sky circle auto-detected — "
                 f"cx={cx:.0f}, cy={cy:.0f}, r={r:.0f}")
         except Exception as exc:
-            app_logger.debug(
-                f"Meteor: sky circle detection failed ({exc}), no mask applied")
+            app_logger.warning(
+                "Meteor: no sky circle (all-sky calibration absent, "
+                f"auto-detect failed: {exc}) — detection runs unmasked "
+                "over the full frame")
 
     def _get_exposure_sec(self) -> float:
         try:


### PR DESCRIPTION
Two silent weeks in the field traced to FrameStack.hot_mask() using an
absolute pixel > 5 test: the linear detection frame's floor sits at the
sensor offset + sky background (10-30 DN, auto-exposure mean ~100), so
every pixel counted as hot and the transient map was zeroed before Hough
ever ran — no detection could fire. The mask is now background-relative
(pixel > per-frame median + threshold, still ANDed over the stack).
Regression tests use a realistic ~25 DN background; the original synthetic
tests all sat on a 0 DN background, which is why this slipped through.

Also:
- Remove the dev-mode gate from the meteor pipeline (controller +
  detection-frame producer). The feature ships under the Beta badge;
  meteor.enabled is the only gate.
- New services/meteor/diagnostics.py: periodic INFO heartbeat with
  per-stage candidate counts (raw -> length -> profile -> released/planes),
  one-shot 'frames stopped since HH:MM:SS' line, roof-gate suspend/resume
  transitions, WARNING when hot-mask coverage exceeds 40% of the frame.
- Sky-circle resolution failure now logs at WARNING with the consequence
  (detection runs unmasked) instead of debug.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FNLVRhLuYhdEG49iSaZQk3